### PR TITLE
Fix NTLMSSP message parsing

### DIFF
--- a/Scripts/Inveigh.ps1
+++ b/Scripts/Inveigh.ps1
@@ -1097,10 +1097,10 @@ $HTTP_scriptblock =
             elseif($HTTP_request_bytes[8] -eq 3)
             {
                 $NTLM = 'NTLM'
-                $HTTP_NTLM_offset = $HTTP_request_bytes[24]
-                $HTTP_NTLM_length = DataLength 22 $HTTP_request_bytes
-                $HTTP_NTLM_domain_length = DataLength 28 $HTTP_request_bytes
-                $HTTP_NTLM_domain_offset = DataLength 32 $HTTP_request_bytes
+                $HTTP_NTLM_length = DataLength2 20 $HTTP_request_bytes
+                $HTTP_NTLM_offset = DataLength4 24 $HTTP_request_bytes
+                $HTTP_NTLM_domain_length = DataLength2 28 $HTTP_request_bytes
+                $HTTP_NTLM_domain_offset = DataLength4 32 $HTTP_request_bytes
                 [String] $NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + '*'
                 $inveigh.HTTP_challenge_queue.Remove($NTLM_challenge)
                 $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(",")) + 1)
@@ -1111,13 +1111,15 @@ $HTTP_scriptblock =
                 }
                 else
                 {  
-                    $HTTP_NTLM_domain_string = DataToString $HTTP_NTLM_domain_length 0 0 $HTTP_NTLM_domain_offset $HTTP_request_bytes
+                    $HTTP_NTLM_domain_string = DataToString $HTTP_NTLM_domain_offset $HTTP_NTLM_domain_length $HTTP_request_bytes
                 } 
                     
-                $HTTP_NTLM_user_length = DataLength 36 $HTTP_request_bytes
-                $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_length $HTTP_NTLM_domain_length 0 $HTTP_NTLM_domain_offset $HTTP_request_bytes     
-                $HTTP_NTLM_host_length = DataLength 44 $HTTP_request_bytes
-                $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_length $HTTP_NTLM_domain_length $HTTP_NTLM_user_length $HTTP_NTLM_domain_offset $HTTP_request_bytes
+                $HTTP_NTLM_user_length = DataLength2 36 $HTTP_request_bytes
+                $HTTP_NTLM_user_offset = DataLength4 40 $HTTP_request_bytes
+                $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_offset $HTTP_NTLM_user_length $HTTP_request_bytes
+                $HTTP_NTLM_host_length = DataLength2 44 $HTTP_request_bytes
+                $HTTP_NTLM_host_offset = DataLength4 48 $HTTP_request_bytes
+                $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_offset $HTTP_NTLM_host_length $HTTP_request_bytes
         
                 if($HTTP_NTLM_length -eq 24) # NTLMv1
                 {


### PR DESCRIPTION
NTLMSSP message parsing may produce bad hashes for SMB traffic. Currently, the determination for NTLMv1 vs. NTLMv2 is based on whether or not the LM response data is all nulls. This causes problems if LMv2 response data is present.

For example the following messages:

    Type 2: 4E544C4D53535000020000000E000E00380000001582896254054C337685F00D00000000000000008E008E00460000000601B11D0000000F500045004E00540045005300540002000E00500045004E00540045005300540001000C0043004F00520050003000310004001600700065006E0074006500730074002E006C00610062000300240043004F0052005000300031002E00700065006E0074006500730074002E006C006100620005001600700065006E0074006500730074002E006C006100620007000800906D68F4BCE4D10100000000570069006E0064006F007700730020003700200045006E0074006500720070007200690073006500200037003600300031002000530065007200760069006300650020005000610063006B00200031000000570069006E0064006F007700730020003700200045006E0074006500720070007200690073006500200036002E0031000000
    Type 3: 4E544C4D53535000030000001800180040000000BA00BA00580000000E000E001201000008000800200100000600060028010000100010002E0100001582086016242E0027F342CC770FA3A2973C17CAC85687C135C6FF3F231E532497736E8CDD56916CD69BF8690101000000000000007275F3BCE4D1011D092999AD83C2940000000002000E00500045004E00540045005300540001000C0043004F00520050003000310004001600700065006E0074006500730074002E006C00610062000300240043004F0052005000300031002E00700065006E0074006500730074002E006C006100620005001600700065006E0074006500730074002E006C006100620007000800906D68F4BCE4D10100000000500045004E00540045005300540075007300650072004400430031004CE02FBB2A064568B252BFF6010DD49B0055006E00690078000000530061006D00620061000000

produce this 'NTLMv1 hash':

    user::PENTEST:16242E0027F342CC770FA3A2973C17CAC85687C135C6FF3F:231E532497736E8CDD56916CD69BF8690101000000000000007275F3BCE4D1011D092999AD83C2940000000002000E00500045004E00540045005300540001000C0043004F00520050003000310004001600700065006E0074006500730074002E006C00610062000300240043004F0052005000300031002E00700065006E0074006500730074002E006C006100620005001600700065006E0074006500730074002E006C006100620007000800906D68F4BCE4D10100000000:54054C337685F00D

NETNTLMv1 hashes should have LM and NT response data fields which are both 24 bytes long. So, the decision should be based on the length of the NT response data.

Sample data with the patch:

    Type 2: 4E544C4D53535000020000000E000E00380000001582896298ADDC7FF5A52C0600000000000000008E008E00460000000601B11D0000000F500045004E00540045005300540002000E00500045004E00540045005300540001000C0043004F00520050003000310004001600700065006E0074006500730074002E006C00610062000300240043004F0052005000300031002E00700065006E0074006500730074002E006C006100620005001600700065006E0074006500730074002E006C006100620007000800E053BAC6C7E4D10100000000570069006E0064006F007700730020003700200045006E0074006500720070007200690073006500200037003600300031002000530065007200760069006300650020005000610063006B00200031000000570069006E0064006F007700730020003700200045006E0074006500720070007200690073006500200036002E0031000000
    Type 3: 4E544C4D53535000030000001800180040000000BA00BA00580000000E000E00120100000A000A0020010000060006002A0100001000100030010000158208607B54192181C4D8B2465C8560277A0A256E869211D06942F6E03B77B8D725D8BCBA9C924463FC88F0010100000000000000F6E1C5C7E4D10104112CA2FA6DE5E70000000002000E00500045004E00540045005300540001000C0043004F00520050003000310004001600700065006E0074006500730074002E006C00610062000300240043004F0052005000300031002E00700065006E0074006500730074002E006C006100620005001600700065006E0074006500730074002E006C006100620007000800E053BAC6C7E4D10100000000500045004E00540045005300540075007300650072003200440043003100F72E379DC5DE71E3777DF3AE676010170055006E00690078000000530061006D00620061000000
    NETNTLMv2 hash: user2::PENTEST:98ADDC7FF5A52C06:E03B77B8D725D8BCBA9C924463FC88F0:010100000000000000F6E1C5C7E4D10104112CA2FA6DE5E70000000002000E00500045004E00540045005300540001000C0043004F00520050003000310004001600700065006E0074006500730074002E006C00610062000300240043004F0052005000300031002E00700065006E0074006500730074002E006C006100620005001600700065006E0074006500730074002E006C006100620007000800E053BAC6C7E4D10100000000

    Type 2: 4E544C4D53535000020000000E000E0038000000158289E25292A6858D7941C300000000000000008E008E00460000000601B11D0000000F500045004E00540045005300540002000E00500045004E00540045005300540001000C0043004F00520050003000310004001600700065006E0074006500730074002E006C00610062000300240043004F0052005000300031002E00700065006E0074006500730074002E006C006100620005001600700065006E0074006500730074002E006C00610062000700080040FE15BAC8E4D10100000000
    Type 3: 4E544C4D5353500003000000180018007C00000018001800940000000E000E00580000000A000A00660000000C000C007000000010001000AC000000158288E20601B11D0000000F1D28866E2A799DC68BE363168A3899A6500045004E0054004500530054007500730065007200330043004F00520050003000320044A4266992E063E50000000000000000000000000000000061B0D2B4AA54807FC489D719E6666D818CE4DEA2304080D25852CAB2ABCE0D0FDBD17568ED9D5BCDA312041001000000F9DE769BB7A575CF00000000
    NETNTLMv1 hash: user3::PENTEST:44A4266992E063E500000000000000000000000000000000:61B0D2B4AA54807FC489D719E6666D818CE4DEA2304080D2:5292A6858D7941C3

This doesn't appear to be a problem with the HTTP variant. Though I haven't tested this (which also means I haven't actually tested the changes which apply to the HTTP code!).